### PR TITLE
FIX: Add core search button back to header when topic title is shown

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,4 +1,5 @@
-.floating-search-input + .panel .header-dropdown-toggle.search-dropdown {
+.floating-search-input + .panel .header-dropdown-toggle.search-dropdown,
+.floating-search-input + .panel .search-menu {
   display: none;
 }
 

--- a/common/common.scss
+++ b/common/common.scss
@@ -1,9 +1,10 @@
-.header-dropdown-toggle.search-dropdown {
+.floating-search-input + .panel .header-dropdown-toggle.search-dropdown {
   display: none;
 }
 
 a.widget-link.search-link {
   padding: 0;
+  color: var(--primary);
 }
 
 .floating-search-input + .panel {

--- a/javascripts/discourse/initializers/header-search.js
+++ b/javascripts/discourse/initializers/header-search.js
@@ -17,13 +17,6 @@ export default {
         <div class="panel clearfix">{{yield}}</div>
       `,
       });
-
-      // api.reopenWidget("header", {
-      //   toggleSearchMenu() {
-      //     // Disable core search menu panel toggling on Esc hit
-      //     return false;
-      //   },
-      // });
     });
   },
 };

--- a/javascripts/discourse/initializers/header-search.js
+++ b/javascripts/discourse/initializers/header-search.js
@@ -18,12 +18,12 @@ export default {
       `,
       });
 
-      api.reopenWidget("header", {
-        toggleSearchMenu() {
-          // Disable core search menu panel toggling on Esc hit
-          return false;
-        },
-      });
+      // api.reopenWidget("header", {
+      //   toggleSearchMenu() {
+      //     // Disable core search menu panel toggling on Esc hit
+      //     return false;
+      //   },
+      // });
     });
   },
 };


### PR DESCRIPTION
This commit allows the search icon to still be shown, allowing users to still use search, when a topic title is placed into the discourse header.