### PR TITLE
UX: hide from logged out users when relevant

### DIFF
--- a/javascripts/discourse/initializers/header-search.js
+++ b/javascripts/discourse/initializers/header-search.js
@@ -11,7 +11,7 @@ export default {
         {{home-logo attrs=attrs}}
         {{#if attrs.topic}}
           {{header-topic-info attrs=attrs}}
-        {{else}}     
+        {{else}}
           {{#unless this.site.mobileView}}
             {{#if this.site.siteSettings.login_required}}
               {{#if this.currentUser}}

--- a/javascripts/discourse/initializers/header-search.js
+++ b/javascripts/discourse/initializers/header-search.js
@@ -12,13 +12,15 @@ export default {
         {{#if attrs.topic}}
           {{header-topic-info attrs=attrs}}
         {{else}}     
-          {{#if this.site.siteSettings.login_required}}
-            {{#if this.currentUser}}
+          {{#unless this.site.mobileView}}
+            {{#if this.site.siteSettings.login_required}}
+              {{#if this.currentUser}}
+                {{floating-search-input attrs=attrs}}
+              {{/if}}
+            {{else}}
               {{floating-search-input attrs=attrs}}
-            {{/if}}
-          {{else}}
-            {{floating-search-input attrs=attrs}}
-          {{/if}}   
+            {{/if}}   
+          {{/unless}}
         {{/if}}
         <div class="panel clearfix">{{yield}}</div>
       `,

--- a/javascripts/discourse/initializers/header-search.js
+++ b/javascripts/discourse/initializers/header-search.js
@@ -11,10 +11,14 @@ export default {
         {{home-logo attrs=attrs}}
         {{#if attrs.topic}}
           {{header-topic-info attrs=attrs}}
-        {{else}}
-          {{#unless this.site.mobileView}}
+        {{else}}     
+          {{#if this.site.siteSettings.login_required}}
+            {{#if this.currentUser}}
+              {{floating-search-input attrs=attrs}}
+            {{/if}}
+          {{else}}
             {{floating-search-input attrs=attrs}}
-          {{/unless}}
+          {{/if}}   
         {{/if}}
         <div class="panel clearfix">{{yield}}</div>
       `,


### PR DESCRIPTION
This prevents the broken search bar from appearing on the `login_required` screen