### PR TITLE
FIX: Sidebar toggle disappearing

### DIFF
--- a/javascripts/discourse/initializers/header-search.js
+++ b/javascripts/discourse/initializers/header-search.js
@@ -8,6 +8,13 @@ export default {
     withPluginApi("0.8.14", (api) => {
       api.reopenWidget("header-contents", {
         template: hbs`
+        {{#if this.site.desktopView}}
+          {{#if this.siteSettings.enable_experimental_sidebar_hamburger}}
+            {{#if attrs.sidebarEnabled}}
+              {{sidebar-toggle attrs=attrs}}
+            {{/if}}
+          {{/if}}
+        {{/if}}
         {{home-logo attrs=attrs}}
         {{#if attrs.topic}}
           {{header-topic-info attrs=attrs}}


### PR DESCRIPTION
This PR fixes an issue where installing `discourse-header-search` causes the new sidebar hamburger toggle to disappear.

This issue was brought up on [Meta](https://meta.discourse.org/t/header-search/194093/24?u=keegan).