### PR TITLE
UX: Ensure spinner icon doesn't overlay

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -32,6 +32,13 @@ a.widget-link.search-link {
         }
         margin: 0 auto;
         position: relative;
+
+        .searching .spinner-holder {
+          display: inline-block;
+          vertical-align: top;
+          margin-left: 4px;
+        }
+
         .widget-button.btn {
           background: transparent;
           padding: 0.25em;

--- a/javascripts/discourse/widgets/search-banner.js
+++ b/javascripts/discourse/widgets/search-banner.js
@@ -54,12 +54,14 @@ export default createWidgetFrom(searchMenu, "floating-search-input", {
       });
     }
 
-    const advancedSearchButton = this.attach("link", {
-      href: this.fullSearchUrl({ expanded: true }),
-      contents: () => iconNode("sliders-h"),
-      className: "show-advanced-search",
-      title: "search.open_advanced",
-    });
+    const advancedSearchButton = loading
+      ? h("div.spinner-holder", h("div.spinner"))
+      : this.attach("link", {
+          href: this.fullSearchUrl({ expanded: true }),
+          contents: () => iconNode("sliders-h"),
+          className: "show-advanced-search",
+          title: "search.open_advanced",
+        });
 
     return [
       h(
@@ -72,7 +74,6 @@ export default createWidgetFrom(searchMenu, "floating-search-input", {
                 icon: "search",
                 action: term ? "fullSearch" : "",
               }),
-              loading ? h("div.searching", h("div.spinner")) : "",
               this.attach("search-term", {
                 value: term,
               }),


### PR DESCRIPTION
Previously, the spinner icon was showing above/below the advanced search one. This switches the markup so that only one of the two is shown:

- when loading, show spinner
- otherwise, show advanced search icon