### PR TITLE
FIX: icon links regression following core changes

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -103,6 +103,7 @@ a.widget-link.search-link {
 .search-bar-icons--icon {
   .d-icon {
     color: var(--primary-low-mid);
+    pointer-events: none;
   }
 
   &:hover .d-icon {

--- a/javascripts/discourse/widgets/search-banner.js
+++ b/javascripts/discourse/widgets/search-banner.js
@@ -110,6 +110,16 @@ export default createWidgetFrom(searchMenu, "floating-search-input", {
       : false;
   },
 
+  mouseDown(e) {
+    // A hacky fix for an issue with core widget event hooks
+    // the `mouseDown` event hook triggers a rerender in core, which
+    // ends up stopping event propagation and preventing the `click` event
+    // for these links
+    if (e.target?.classList?.contains("search-bar-icons--icon")) {
+      e.target.click();
+    }
+  },
+
   linkClickedEvent(attrs) {
     const { searchLogId, searchResultId, searchResultType } = attrs;
     if (searchLogId && searchResultId && searchResultType) {


### PR DESCRIPTION
In https://github.com/discourse/discourse/commit/34ffc0065ac17244109f7e6da0758cc85ec70bec we added a `mouseDown` event hook to the search banner widget. That widget hook triggers a rerender in core, which ends up stopping event propagation and preventing the `click` event for these links.

This is a quick and dirty fix here, I think core should not rerender a widget for the `mousedown` and `mouseup` hooks.