### PR TITLE
DEV: add class for `mountWidget`, use `@outletArgs`

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -24,6 +24,11 @@ a.widget-link.search-link {
   margin-left: 0;
 }
 
+.floating-search-input-wrapper {
+  display: flex;
+  align-items: center;
+}
+
 .floating-search-input {
   width: 50%;
   margin: 0 auto;

--- a/javascripts/discourse/connectors/before-header-panel/connector.hbs
+++ b/javascripts/discourse/connectors/before-header-panel/connector.hbs
@@ -6,10 +6,11 @@
       (not this.site.siteSettings.login_required)
     )
   }}
-    {{! @attrs.topic does not work here }}
-    {{! template-lint-disable no-args-paths }}
-    {{#unless this.args.attrs.topic}}
-      <MountWidget @widget="search-banner" />
+    {{#unless @outletArgs.attrs.topic}}
+      <MountWidget
+        @widget="search-banner"
+        @class="floating-search-input-wrapper"
+      />
     {{/unless}}
   {{/if}}
 {{/unless}}


### PR DESCRIPTION
The class name doesn't change any functionality, but makes this theme component easier to work with when it shares a common outlet with another theme component. 