### PR TITLE
DEV: Lower Plugin API version

### DIFF
--- a/javascripts/discourse/initializers/search-banner.js
+++ b/javascripts/discourse/initializers/search-banner.js
@@ -4,7 +4,7 @@ export default {
   name: "search-banner",
 
   initialize() {
-    withPluginApi("1.17.0", (api) => {
+    withPluginApi("1.1.0", (api) => {
       api.reopenWidget("header", {
         didRenderWidget() {
           document


### PR DESCRIPTION
The search banner initializer was pointing to a recent version of the core Plugin API which could cause issues if a discourse instance was utilizing the `discourse-header-search` component but had not updated to a recent version of core. This PR brings the Plugin API version down to a version that will provide more wiggle room for people to run the theme component without issues on older versions of core.