### PR TITLE
Fix deprecation : Importing getOwner from discourse-common/lib/get-owner

### DIFF
--- a/javascripts/discourse/components/search-bar-icons.js
+++ b/javascripts/discourse/components/search-bar-icons.js
@@ -1,6 +1,6 @@
 import Component from "@glimmer/component";
+import { getOwner } from "@ember/application";
 import { inject as service } from "@ember/service";
-import { getOwner } from "@ember/application"
 
 export default class SearchBarIcons extends Component {
   @service router;

--- a/javascripts/discourse/components/search-bar-icons.js
+++ b/javascripts/discourse/components/search-bar-icons.js
@@ -1,6 +1,6 @@
 import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwner } from "@ember/application"
 
 export default class SearchBarIcons extends Component {
   @service router;


### PR DESCRIPTION
As mentioned [here](https://meta.discourse.org/t/ember-object-ownership-getowner-service-injections-etc/292080), this should fix the deprecation notice below 

> search-bar-icons.js:47 [THEME 21 'Discourse Header Search'] Deprecation notice: Importing getOwner from `discourse-common/lib/get-owner` is deprecated. See the alternatives on meta. [deprecated since Discourse 3.2] [deprecation id: discourse.get-owner-with-fallback] [info: https://meta.discourse.org/t/292080]