### PR TITLE
FIX: show search until topic title is docked

### DIFF
--- a/javascripts/discourse/components/header-search.hbs
+++ b/javascripts/discourse/components/header-search.hbs
@@ -1,5 +1,5 @@
 {{#if this.shouldDisplay}}
-{{body-class "search-header--visible"}}
+  {{body-class "search-header--visible"}}
   <div class="floating-search-input-wrapper">
     <div class="floating-search-input">
       <div class="search-banner">

--- a/javascripts/discourse/components/header-search.js
+++ b/javascripts/discourse/components/header-search.js
@@ -3,7 +3,6 @@ import { inject as service } from "@ember/service";
 
 export default class HeaderSearch extends Component {
   @service site;
-  @service router;
   @service siteSettings;
   @service currentUser;
 
@@ -15,10 +14,12 @@ export default class HeaderSearch extends Component {
   }
 
   get shouldDisplay() {
+    const titleDocked = this.args.outletArgs?.topic;
+
     return (
       this.displayForUser &&
       !this.site.mobileView &&
-      !this.router.currentRoute.name.includes("topic")
+      !titleDocked
     );
   }
 }

--- a/javascripts/discourse/components/header-search.js
+++ b/javascripts/discourse/components/header-search.js
@@ -16,10 +16,6 @@ export default class HeaderSearch extends Component {
   get shouldDisplay() {
     const titleDocked = this.args.outletArgs?.topic;
 
-    return (
-      this.displayForUser &&
-      !this.site.mobileView &&
-      !titleDocked
-    );
+    return this.displayForUser && !this.site.mobileView && !titleDocked;
   }
 }


### PR DESCRIPTION
Using the router here meant that the search was always hidden in topics:

![image](https://github.com/discourse/discourse-header-search/assets/1681963/92fd1ae0-c564-43ce-aabe-bca4e46511b6)


Using the topic argument means that the search won't be hidden until the topic title docks, which was the previous behavior before 113818cb644c76a75691fd7c36b50999d07b58a7: 

![image](https://github.com/discourse/discourse-header-search/assets/1681963/3baecea4-ba2a-40f6-a0dc-93cfc2b67094)
